### PR TITLE
Change filenames and command stdout

### DIFF
--- a/generate-api-types.js
+++ b/generate-api-types.js
@@ -94,7 +94,7 @@ async function loadOpenAPISchema(args, importOrder) {
             options.cwd = args['command-cwd'];
           }
 
-          const openAPIFile = execSync(args['oas-command'], options);
+          openAPIFile = execSync(args['oas-command'], options);
           return JSON.parse(openAPIFile);
         }
         case 'oas-url': {

--- a/generate-api-types.js
+++ b/generate-api-types.js
@@ -14,7 +14,7 @@ function isOptionToken(token) {
 }
 
 function getArgs() {
-  const {values: args, tokens} = parseArgs({
+  const { values: args, tokens } = parseArgs({
     options: {
       // The import root of the JS project.
       'project-root': {
@@ -73,7 +73,7 @@ function getArgs() {
     .sort((a, b) => a.index - b.index)
     .map(token => token.name);
 
-  return {args, importOrder};
+  return { args, importOrder };
 }
 
 /**
@@ -88,11 +88,13 @@ async function loadOpenAPISchema(args, importOrder) {
           openAPIFile = fs.readFileSync(args['oas-path']);
           return JSON.parse(openAPIFile);
         case 'oas-command': {
-          const options = {stdio: 'inherit'};
+          const options = { stdio: ['inherit', 'pipe', 'inherit'] };
+
           if (args['command-cwd']) {
             options.cwd = args['command-cwd'];
           }
-          openAPIFile = execSync(args['oas-command'], options);
+
+          const openAPIFile = execSync(args['oas-command'], options);
           return JSON.parse(openAPIFile);
         }
         case 'oas-url': {
@@ -101,7 +103,7 @@ async function loadOpenAPISchema(args, importOrder) {
             controller.abort()
           }, 5000)
           let response;
-          response = await fetch(args['oas-url'], {signal: controller.signal});
+          response = await fetch(args['oas-url'], { signal: controller.signal });
           clearTimeout(timeout)
           return await response.json();
         }
@@ -186,7 +188,7 @@ function generateReExporterFile(typeFile, typesDir, enumLookup) {
   const schemasNode = componentProperties.find(node => node.type === 'TSPropertySignature' && node.key.name === 'schemas');
   const schemaProperties = schemasNode.typeAnnotation.typeAnnotation.members;
   const openAPIPath = path.join(typesDir, 'openapi');
-  
+
   let reExporterLines = [`import { components } from '${openAPIPath}';\n`];
   if (Object.keys(enumLookup).length > 0) {
     reExporterLines.push('export {');
@@ -206,10 +208,10 @@ function generateReExporterFile(typeFile, typesDir, enumLookup) {
   return reExporterLines.join('\n');
 }
 
-const {args, importOrder} = getArgs();
+const { args, importOrder } = getArgs();
 const openAPISchema = await loadOpenAPISchema(args, importOrder);
-const schemaHash = hash({...openAPISchema, typeGeneratorVersion: pkg.version});
-const openAPIGeneratedPath = path.join(args['project-root'], args['types-dir'], 'openapi.ts');
+const schemaHash = hash({ ...openAPISchema, typeGeneratorVersion: pkg.version });
+const openAPIGeneratedPath = path.join(args['project-root'], args['types-dir'], 'openapi.d.ts');
 const prevSchemaHash = getSchemaHash(openAPIGeneratedPath)
 if (prevSchemaHash === schemaHash) {
   console.log("OpenAPI file has not changed, skipping generation.");
@@ -219,7 +221,7 @@ const enumLookup = {};
 
 let typeFile;
 try {
-  typeFile = await openapiTS(openAPISchema, {transform});
+  typeFile = await openapiTS(openAPISchema, { transform });
 } catch (e) {
   console.log(e);
   process.exit(0);
@@ -231,11 +233,11 @@ typeFile += '\n' + enumDefs + '\n';
 
 fs.writeFileSync(openAPIGeneratedPath, typeFile);
 const reExporterFile = generateReExporterFile(typeFile, args['types-dir'], enumLookup);
-const schemasPath = path.join(args['project-root'], args['types-dir'], 'schemas.ts');
+const schemasPath = path.join(args['project-root'], args['types-dir'], 'schemas.d.ts');
 fs.writeFileSync(schemasPath, reExporterFile);
 if (args['auto-add']) {
   try {
-    execSync(`git add ${openAPIGeneratedPath} ${schemasPath}`, {stdio: 'inherit'}); 
+    execSync(`git add ${openAPIGeneratedPath} ${schemasPath}`, { stdio: 'inherit' });
   } catch (e) {
     // We're non inside the Git repo, so we can't add the files.
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-type-generator",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-type-generator",
-      "version": "1.0.4",
+      "version": "1.0.6",
       "license": "UNLICENSED",
       "dependencies": {
         "@typescript-eslint/parser": "^6.7.0",


### PR DESCRIPTION
Fixes:

* The `execSync` was running with `stdio = ['inherit', 'inherit', 'inherit']` which causes the open api to be printed to the screen and curiously makes the return buffer `null`
* The hashing stuff was using `openapi.ts` and `schema.ts` although the repo has them as `openapi.d.ts`, ...